### PR TITLE
feat: entity ids

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 PEER_URL=https://peer.decentraland.org
-PREVIEW_URL=http://localhost:8080
+PREVIEW_URL=http://127.0.0.1:8080
 AWS_REGION=us-east-1
-AWS_ENDPOINT=http://localhost:4566
+AWS_ENDPOINT=http://127.0.0.1:4566
 AWS_ACCESS_KEY_ID=
 AWS_SECREAT_ACCESS_KEY=
 QUEUE_NAME=profile-images-queue

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -18,16 +18,16 @@ const snapshot = new Snapshot();
 
 async function job() {
   const didWork = await queue.receive(async (message) => {
-    console.log(`Processing: ${message.address}`);
-    console.time("Snapshots");
+    console.log(`Processing: ${message.entity}`);
+    console.time(`Snapshots ${message.entity}`);
     const [face, body] = await Promise.all([
       snapshot.getFace(message.address),
       snapshot.getBody(message.address),
     ]);
-    console.timeEnd("Snapshots");
-    console.time("Upload");
-    await bucket.saveSnapshots(message.address, face, body);
-    console.timeEnd("Upload");
+    console.timeEnd(`Snapshots ${message.entity}`);
+    console.time(`Upload ${message.entity}`);
+    await bucket.saveSnapshots(message.entity, face, body);
+    console.timeEnd(`Upload ${message.entity}`);
   }, config.MAX_JOBS);
   if (!didWork) {
     console.log(`Queue empty`);

--- a/src/modules/browser.ts
+++ b/src/modules/browser.ts
@@ -43,12 +43,22 @@ export class Browser {
       await page.close();
       return buffer as Buffer;
     } catch (error) {
-      this.reset();
+      await this.reset();
       throw error;
     }
   }
 
-  reset() {
+  async close() {
+    const browser = await this.getBrowser();
+    return browser.close();
+  }
+
+  async reset() {
+    try {
+      await this.close();
+    } catch (error) {
+      console.error(`Could not close browser`, error);
+    }
     delete this.browser;
   }
 }

--- a/src/modules/browser.ts
+++ b/src/modules/browser.ts
@@ -24,25 +24,31 @@ export class Browser {
     return this.browser!;
   }
   async takeScreenshot(url: string, selector: string, viewport: ViewPort) {
-    const start = new Date().getTime();
-    const browser = await this.getBrowser();
-    const page = await browser.newPage();
-    await page.setViewport({
-      deviceScaleFactor: 2,
-      ...viewport,
-    });
-    await page.goto(url);
-    const container = await page.waitForSelector(selector);
-    if (!container) {
-      throw new Error(`Could not generate screenshot`);
+    try {
+      const browser = await this.getBrowser();
+      const page = await browser.newPage();
+      await page.setViewport({
+        deviceScaleFactor: 2,
+        ...viewport,
+      });
+      await page.goto(url);
+      const container = await page.waitForSelector(selector);
+      if (!container) {
+        throw new Error(`Could not generate screenshot`);
+      }
+      const buffer = await container.screenshot({
+        encoding: "binary",
+        omitBackground: true,
+      });
+      await page.close();
+      return buffer as Buffer;
+    } catch (error) {
+      this.reset();
+      throw error;
     }
-    const buffer = await container.screenshot({
-      encoding: "binary",
-      omitBackground: true,
-    });
-    await page.close();
-    const end = new Date().getTime();
-    console.log(`Screenshot for ${url} took ${end - start}ms`)
-    return buffer as Buffer;
+  }
+
+  reset() {
+    delete this.browser;
   }
 }

--- a/src/modules/bucket.ts
+++ b/src/modules/bucket.ts
@@ -7,12 +7,12 @@ export class Bucket {
     public bucketName: string,
     public cache: number
   ) {}
-  async saveSnapshots(address: string, face: Buffer, body: Buffer) {
+  async saveSnapshots(entity: string, face: Buffer, body: Buffer) {
     const faceUpload = new Upload({
       client: this.client,
       params: {
         Bucket: this.bucketName,
-        Key: `addresses/${address}/face.png`,
+        Key: `entities/${entity}/face.png`,
         Body: face,
         ContentType: "image/png",
         CacheControl: `max-age=${this.cache}`,
@@ -23,7 +23,7 @@ export class Bucket {
       client: this.client,
       params: {
         Bucket: this.bucketName,
-        Key: `addresses/${address}/body.png`,
+        Key: `entities/${entity}/body.png`,
         Body: body,
         ContentType: "image/png",
         CacheControl: `max-age=${this.cache}`,

--- a/src/modules/peer.ts
+++ b/src/modules/peer.ts
@@ -2,7 +2,7 @@ import fetch from "node-fetch";
 import { Entity, EntityType, Profile } from "@dcl/schemas";
 import { config } from "./config";
 
-type Delta = Omit<Entity, "metadata"> & { metadata: Profile };
+type Delta = Omit<Entity, "metadata"> & { metadata: Profile; entityId: string };
 
 type PointerChangesResponse = {
   deltas: Delta[];
@@ -18,19 +18,19 @@ type PointerChangesResponse = {
   };
 };
 
-export async function getAddressesWithChanges(peerUrl: string, from: number) {
+export async function getProfilesWithChanges(peerUrl: string, from: number) {
   const now = Date.now();
   const url = `${peerUrl}/content/pointer-changes?entityType=${EntityType.PROFILE}&from=${from}&to=${now}`;
   const response = await fetch(url);
   if (response.ok) {
     const data: PointerChangesResponse = await response.json();
-    const addresses = new Set<string>();
+    const profiles = new Map<string, string>();
     for (const profile of data.deltas) {
       for (const address of profile.pointers) {
-        addresses.add(address);
+        profiles.set(address, profile.entityId);
       }
     }
-    return { addresses: Array.from(addresses), timestamp: now };
+    return { profiles: Array.from(profiles), timestamp: now };
   } else {
     const text = await response.text();
     throw new Error(`Could not load pointer changes: "${text}"`);

--- a/src/producer.ts
+++ b/src/producer.ts
@@ -1,6 +1,6 @@
 import { SQSClient } from "@aws-sdk/client-sqs";
 import { config, getAWSConfig } from "./modules/config";
-import { getAddressesWithChanges } from "./modules/peer";
+import { getProfilesWithChanges } from "./modules/peer";
 import { sleep } from "./modules/sleep";
 import { Queue, QueueMessage } from "./modules/queue";
 
@@ -15,15 +15,15 @@ async function poll(
 ): Promise<void> {
   try {
     console.log(`Polling changes...`);
-    const { addresses, timestamp } = await getAddressesWithChanges(
+    const { profiles, timestamp } = await getProfilesWithChanges(
       peerUrl,
       lastTimestamp
     );
-    console.log(`Results: ${addresses.length}`);
-    for (const address of addresses) {
-      const message: QueueMessage = { address };
+    console.log(`Results: ${profiles.length}`);
+    for (const [address, entity] of profiles) {
+      const message: QueueMessage = { address, entity };
       await queue.send(message);
-      console.log(`Added to queue: ${address}`);
+      console.log(`Added to queue address="${address}" and entity="${entity}"`);
     }
     await sleep(ms);
     return await poll(peerUrl, ms, timestamp);


### PR DESCRIPTION
This PR changes the service to store the images under the profile entity ID instead of the user address, to allow for better caching of images.

It also fixes a few minor issues, like some warnings when running moret than one job at a time, replacing `localhost` with `127.0.0.1` in the example to play nice with node 18, and reseting the browser if something goes wrong while taking the screenshots.