### PR TITLE
chore: bump godot-explorer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/decentraland/godot-explorer:4fa8e16a3fdf649fd6b7323adfc4298981762c7a
+FROM quay.io/decentraland/godot-explorer:17cfaeb71b0c674d3cc8d8ede3e3de18f1ac216a
 
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y ca-certificates tini


### PR DESCRIPTION
Bump to a working version. I've tested it locally, and it passed my manual test. After merging it, we should test it further and also plan automated tests for it.