### PR TITLE
feat: Observe duration between deployment and image upload

### DIFF
--- a/src/logic/image-processor.ts
+++ b/src/logic/image-processor.ts
@@ -30,6 +30,8 @@ export async function createImageProcessor({
       return []
     }
 
+    const deploymentTimestamps = new Map<string, number>(entities.map(({ id, timestamp }) => [id, timestamp]))
+
     const avatars: ExtendedAvatar[] = entities.map(({ id, metadata }) => ({
       entity: id,
       avatar: metadata.avatars[0].avatar
@@ -52,6 +54,12 @@ export async function createImageProcessor({
               error: 'Failed to store images',
               avatar: result.avatar
             }
+          }
+
+          const deploymentTimestamp = deploymentTimestamps.get(result.entity)
+          if (deploymentTimestamp) {
+            const durationInSeconds = (Date.now() - deploymentTimestamp) / 1000
+            metrics.observe('entity_deployment_to_image_generation_duration_seconds', {}, durationInSeconds)
           }
 
           return {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -20,6 +20,11 @@ export const metricDeclarations = {
     help: 'Histogram of image upload duration',
     type: IMetricsComponent.HistogramType,
     labelNames: ['status']
+  },
+  entity_deployment_to_image_generation_duration_seconds: {
+    help: 'Histogram of duration from entity deployment to image generation completion',
+    type: IMetricsComponent.HistogramType,
+    buckets: [0.1, 0.5, 1, 2, 5, 10, 15, 30, 60, 120]
   }
 }
 


### PR DESCRIPTION
Add a new metric to observe the duration of the whole flow from Entity deployment to generation and upload to the S3.