### PR TITLE
chore: bucket migration

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -18,3 +18,6 @@ QUEUE_URL=profile-images-queue-url
 DLQ_URL=profile-images-dlq-url
 
 AUTH_SECRET=secret
+
+#SOURCE_BUCKET_NAME=
+#SOURCE_S3_IMAGES_PREFIX=

--- a/src/migrations/bucket-migration.ts
+++ b/src/migrations/bucket-migration.ts
@@ -1,0 +1,137 @@
+import { CopyObjectCommand, HeadObjectCommand, ListObjectsV2Command, S3Client, _Object } from '@aws-sdk/client-s3'
+import { IConfigComponent, ILoggerComponent } from '@well-known-components/interfaces'
+import { AwsConfig } from '../adapters/aws-config'
+
+const CONCURRENCY = 20
+const LOG_EVERY = 100
+const MAX_RETRIES = 3
+
+type MigrationComponents = {
+  config: IConfigComponent
+  logs: ILoggerComponent
+  awsConfig: AwsConfig
+}
+
+export async function runBucketMigration({ config, logs, awsConfig }: MigrationComponents): Promise<void> {
+  const logger = logs.getLogger('bucket-migration')
+
+  const sourceBucket = await config.getString('SOURCE_BUCKET_NAME')
+  if (!sourceBucket) {
+    logger.info('SOURCE_BUCKET_NAME not set, skipping bucket migration')
+    return
+  }
+
+  const destinationBucket = await config.requireString('BUCKET_NAME')
+  const destinationPrefix = (await config.getString('S3_IMAGES_PREFIX')) || ''
+  const sourcePrefix = (await config.getString('SOURCE_S3_IMAGES_PREFIX')) || destinationPrefix
+
+  logger.info(
+    `Starting bucket migration from "${sourceBucket}" (prefix: "${sourcePrefix}") to "${destinationBucket}" (prefix: "${destinationPrefix}")`
+  )
+
+  const s3 = new S3Client(awsConfig)
+
+  let totalListed = 0
+  let copied = 0
+  let skipped = 0
+  let failed = 0
+  let continuationToken: string | undefined
+
+  do {
+    const listCommand = new ListObjectsV2Command({
+      Bucket: sourceBucket,
+      Prefix: sourcePrefix || undefined,
+      ContinuationToken: continuationToken
+    })
+
+    const listResult = await s3.send(listCommand)
+    const objects = listResult.Contents || []
+    totalListed += objects.length
+    continuationToken = listResult.NextContinuationToken
+
+    // Process objects with concurrency limit
+    const chunks = chunkArray<_Object>(objects, CONCURRENCY)
+    for (const chunk of chunks) {
+      const results = await Promise.allSettled(
+        chunk.map(async (obj) => {
+          if (!obj.Key) return 'skipped'
+
+          const destinationKey =
+            sourcePrefix !== destinationPrefix ? obj.Key.replace(sourcePrefix, destinationPrefix) : obj.Key
+
+          // Check if object already exists in destination
+          try {
+            await s3.send(new HeadObjectCommand({ Bucket: destinationBucket, Key: destinationKey }))
+            return 'skipped' // already exists
+          } catch (err: any) {
+            if (err.name !== 'NotFound' && err.$metadata?.httpStatusCode !== 404) {
+              throw err
+            }
+            // Object doesn't exist, proceed with copy
+          }
+
+          await copyWithRetry(s3, sourceBucket, obj.Key, destinationBucket, destinationKey)
+          return 'copied'
+        })
+      )
+
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          if (result.value === 'copied') copied++
+          else skipped++
+        } else {
+          failed++
+          logger.warn(`Failed to copy object: ${result.reason}`)
+        }
+      }
+
+      if ((copied + skipped + failed) % LOG_EVERY < CONCURRENCY) {
+        logger.info(
+          `Migration progress: ${copied} copied, ${skipped} skipped, ${failed} failed (${totalListed} listed so far)`
+        )
+      }
+    }
+  } while (continuationToken)
+
+  logger.info(
+    `Bucket migration complete: ${copied} copied, ${skipped} skipped, ${failed} failed out of ${totalListed} total objects`
+  )
+}
+
+async function copyWithRetry(
+  s3: S3Client,
+  sourceBucket: string,
+  sourceKey: string,
+  destinationBucket: string,
+  destinationKey: string
+): Promise<void> {
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      await s3.send(
+        new CopyObjectCommand({
+          Bucket: destinationBucket,
+          Key: destinationKey,
+          CopySource: encodeURI(`${sourceBucket}/${sourceKey}`),
+          MetadataDirective: 'COPY'
+        })
+      )
+      return
+    } catch (err: any) {
+      if (err.name === 'NoSuchKey') return // source object disappeared, skip
+      if (attempt === MAX_RETRIES) throw err
+      await sleep(Math.pow(2, attempt - 1) * 1000)
+    }
+  }
+}
+
+function chunkArray<T>(array: T[], size: number): T[][] {
+  const chunks: T[][] = []
+  for (let i = 0; i < array.length; i += size) {
+    chunks.push(array.slice(i, i + size))
+  }
+  return chunks
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,6 +1,7 @@
 import { Lifecycle } from '@well-known-components/interfaces'
 import { setupRouter } from './controllers/routes'
 import { AppComponents, GlobalContext, TestComponents } from './types'
+import { runBucketMigration } from './migrations/bucket-migration'
 
 // this function wires the business logic (adapters & controllers) with the components (ports)
 export async function main(program: Lifecycle.EntryPointParameters<AppComponents | TestComponents>) {
@@ -20,4 +21,7 @@ export async function main(program: Lifecycle.EntryPointParameters<AppComponents
 
   // start ports: db, listeners, synchronizations, etc
   await startComponents()
+
+  // run bucket migration if SOURCE_BUCKET_NAME is configured
+  await runBucketMigration(components)
 }


### PR DESCRIPTION
**S3 Bucket Migration for Profile Images**

We need to move profile images from the current S3 bucket to a new one with zero downtime.

**Approach**

A startup migration built into the profile-images service, controlled by an env var:

1. Deploy with BUCKET_NAME=<new-bucket> and SOURCE_BUCKET_NAME=<old-bucket>
2. Service starts normally (HTTP healthy, consumer processing new events into the new bucket)
3. Migration runs after startup: lists all objects in the source bucket and server-side copies them to the destination (20 concurrent copies, retries, skips objects that already exist in destination)
4. Once logs confirm migration is complete → switch CDN origin to the new bucket
5. Redeploy without SOURCE_BUCKET_NAME to disable migration on future restarts

**Key details**

- HeadObjectCommand check before each copy prevents overwriting newer images written by the consumer during migration
- No dual-write needed — the consumer writes to BUCKET_NAME (new bucket) from the start
- Migration copies everything in the bucket (entities, failures, timestamp), no filtering
- Idempotent: safe to restart, already-copied objects are skipped

**Files changed**

- src/migrations/bucket-migration.ts — new migration module
- src/service.ts — hooks migration after startComponents()
- .env.default — adds SOURCE_BUCKET_NAME and SOURCE_S3_IMAGES_PREFIX