### PR TITLE
chore: update godot-explorer image tag to 7714517

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/decentraland/godot-explorer:4b4774d520db7f6c06a7930ca7c85a8be6528a78
+FROM quay.io/decentraland/godot-explorer:7714517e196bde025f838ad16dec802781085ef9
 
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y ca-certificates tini


### PR DESCRIPTION
## Summary
- Updates the `godot-explorer` base image tag from `4b4774d` to `7714517e196bde025f838ad16dec802781085ef9`

## Test plan
- [ ] Deploy and verify the Godot renderer produces correct avatar images