### PR TITLE
fix: clean up godot temp avatar files to prevent enospc

### DIFF
--- a/src/adapters/godot.ts
+++ b/src/adapters/godot.ts
@@ -97,11 +97,22 @@ export async function createGodotSnapshotComponent({
 
       let resolved = false
 
+      // Removes the temp avatar payload file. Without this, files accumulate on
+      // each run and exhaust the Fargate 20 GiB ephemeral storage after ~2h.
+      const cleanupTempFile = () =>
+        rm(avatarDataPath, { force: true }).catch((err) =>
+          logger.error('Failed to remove temp avatar file', {
+            path: avatarDataPath,
+            message: (err as Error).message
+          })
+        )
+
       // Set a failsafe timeout that will kill the process group if the command hasn't finished.
-      const timeoutHandler: NodeJS.Timeout = setTimeout(() => {
+      const timeoutHandler: NodeJS.Timeout = setTimeout(async () => {
         killProcessGroup(childProcessPid)
         if (!resolved) {
           resolved = true
+          await cleanupTempFile()
           resolve({ error: true, stdout: '', stderr: 'timeout' })
         }
       }, timeout + 5000)
@@ -110,7 +121,7 @@ export async function createGodotSnapshotComponent({
       const childProcess = exec(
         command,
         { timeout } as any,
-        (error: ExecException | null, stdout: string, stderr: string) => {
+        async (error: ExecException | null, stdout: string, stderr: string) => {
           if (resolved) return
           clearTimeout(timeoutHandler)
           if (error) {
@@ -118,9 +129,11 @@ export async function createGodotSnapshotComponent({
               rm(f).catch(logger.error)
             }
             resolved = true
+            await cleanupTempFile()
             return resolve({ error: true, stdout, stderr })
           }
           resolved = true
+          await cleanupTempFile()
           resolve({ error: false, stdout, stderr })
         }
       )

--- a/test/unit/adapters/godot.spec.ts
+++ b/test/unit/adapters/godot.spec.ts
@@ -69,6 +69,39 @@ describe('when generating images with Godot', () => {
       expect(mkdir).toHaveBeenCalledWith('output', { recursive: true })
       expect(writeFile).toHaveBeenCalled()
     })
+
+    it('should remove the temp avatar payload file after the run', async () => {
+      const writeFileMock = writeFile as jest.Mock
+      await godot.generateImages(testAvatars)
+
+      const writtenPath = writeFileMock.mock.calls[0][0] as string
+      expect(writtenPath).toMatch(/^temp-avatars-\d+\.json$/)
+      expect(rm).toHaveBeenCalledWith(writtenPath, { force: true })
+    })
+  })
+
+  describe('and process fails with an error', () => {
+    beforeEach(() => {
+      mockExec.mockImplementation((...args) => {
+        const isGodot = args.find((arg) => typeof arg === 'string' && arg.includes('godot'))
+        const callback = args.find((arg) => typeof arg === 'function')
+        if (isGodot) {
+          callback(new Error('Process failed'), '', 'error output')
+        } else {
+          callback(null, 'success', '')
+        }
+        return mockChildProcess
+      })
+      ;(stat as jest.Mock).mockRejectedValue(new Error('nope'))
+    })
+
+    it('should remove the temp avatar payload file even when godot fails', async () => {
+      const writeFileMock = writeFile as jest.Mock
+      await godot.generateImages(testAvatars)
+
+      const writtenPath = writeFileMock.mock.calls[0][0] as string
+      expect(rm).toHaveBeenCalledWith(writtenPath, { force: true })
+    })
   })
 
   describe('and process fails', () => {
@@ -144,10 +177,13 @@ describe('when generating images with Godot', () => {
     })
 
     it('should timeout when process takes too long', async () => {
+      const writeFileMock = writeFile as jest.Mock
       const result = await godot.generateImages(testAvatars)
 
       expect(result.avatars[0].success).toBe(false)
       expect(result.output).toContain('timeout')
+      const writtenPath = writeFileMock.mock.calls[0][0] as string
+      expect(rm).toHaveBeenCalledWith(writtenPath, { force: true })
     }, 10_000)
   })
 })


### PR DESCRIPTION
## Changes

  - Remove `temp-avatars-*.json` files written by the Godot avatar renderer after each run, in all three resolution paths (success, error, and
  failsafe timeout).
  - Without this, files accumulated on every render batch and exhausted the 20 GiB Fargate ephemeral storage after ~2h, crashing the worker with
  `ENOSPC: no space left on device`.
  - Add unit tests covering cleanup on success, error, and timeout paths.

  ## Context

  Production incident on the `profile-images-worker-blue` ECS service: task ran ~2h 23m before storage writes hit the 20 GiB ephemeral limit.
  Storage Write metric climbed steadily from 14.6 GB to 18.2 GB over the final 30 minutes; CPU and memory were healthy. The renderer was writing
  `temp-avatars-${executionNumber}.json` per call without removing them.

  ## Test plan

  - [x] `yarn lint:fix`
  - [x] `yarn build`
  - [x] `yarn test:unit` (144 passed)
  - [ ] Verify in staging that `temp-avatars-*.json` does not accumulate across multiple render batches