### PR TITLE
fix: disable core dumps to prevent ephemeral disk fill

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,9 @@
 # turn on bash's job control
 set -m
 
+# Disable core dumps (godot writes ~348MB cores per run, fills Fargate disk).
+ulimit -c 0
+
 /usr/bin/Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
 export DISPLAY=:99
 /usr/bin/node --trace-warnings --abort-on-uncaught-exception --unhandled-rejections=strict dist/index.js


### PR DESCRIPTION
## Summary

- Add `ulimit -c 0` to `entrypoint.sh` so the worker container does not write core dumps.
- The godot child process segfaults on shutdown after each render (renders themselves complete successfully). The kernel writes ~348MB to `/app/core.<PID>` per run, filling Fargate's 20 GiB ephemeral storage in ~2h.
- Confirmed by the diagnostic logs from PR #151:
  ```
  disk new run=80: 348M=/app/core.7962 ...
  disk new run=81: 349M=/app/core.8052 ...
  disk new run=82: 348M=/app/core.8143 ...
  ```
  Every run, ~348MB. Renders are fine; only the post-render core dump is the leak.

## Test plan

- [ ] Deploy to staging.
- [ ] Confirm via `disk new` log lines (from PR #151) that `/app/core.*` no longer appears after each godot run.
- [ ] Confirm `df` does not climb past baseline over a multi-hour run.