### PR TITLE
feat: pass --dclenv to godot so .zone wearables resolve correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/decentraland/godot-explorer:8ed31d84089cba0d4c37243ed48160ad6cd6f6ff
+FROM quay.io/decentraland/godot-explorer:be6db73f926425785932d9b6aa8b97c43beafb91
 
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y ca-certificates tini

--- a/src/adapters/godot.ts
+++ b/src/adapters/godot.ts
@@ -29,18 +29,39 @@ const height = 512
 const faceWidth = 256
 const faceHeight = 256
 
+// Derive the godot-explorer `dclenv` value from the configured peer URL.
+// The renderer's wearable fetcher reads `urls::peer_content()`, which is
+// keyed off a global `dclenv` (default: `org`). Pointing PEER_URL at .zone
+// fixes the profile fetch but NOT the `entities/active` POST for wearables
+// — we must also pass `--dclenv` so `set_dcl_environment` runs before the
+// first wearable lookup. See decentraland/godot-explorer/docs/PROFILE_IMAGE.md.
+export function inferDclEnvFromPeerUrl(peerUrl: string): 'org' | 'zone' | 'today' {
+  let host = ''
+  try {
+    host = new URL(peerUrl).hostname.toLowerCase()
+  } catch {
+    return 'org'
+  }
+  if (host === 'peer-testing.decentraland.org') return 'today'
+  if (host.endsWith('.decentraland.zone')) return 'zone'
+  return 'org'
+}
+
 export async function createGodotSnapshotComponent({
   logs,
   metrics,
   config
 }: Pick<AppComponents, 'logs' | 'metrics' | 'config'>): Promise<GodotComponent> {
   const peerUrl = await config.requireString('PEER_URL')
+  const dclenv = inferDclEnvFromPeerUrl(peerUrl)
   const logger = logs.getLogger('godot-snapshot')
   const explorerPath = process.env.EXPLORER_PATH || '.'
   const godotEditorFileName = 'decentraland.godot.client.x86_64'
   const godotEditorPath = `${explorerPath}/${godotEditorFileName}`
   const baseTime = (await config.getNumber('GODOT_BASE_TIMEOUT')) || 15_000
   const timePerAvatar = (await config.getNumber('GODOT_AVATAR_TIMEOUT')) || 10_000
+
+  logger.info(`godot snapshot configured with peerUrl=${peerUrl} dclenv=${dclenv}`)
 
   let executionNumber = 0
 
@@ -90,7 +111,8 @@ export async function createGodotSnapshotComponent({
       await writeFile(avatarDataPath, JSON.stringify(input))
 
       await mkdir(outputPath, { recursive: true })
-      const command = `${godotEditorPath} --rendering-driver opengl3 --avatar-renderer --avatars ${avatarDataPath}`
+      const dclenvFlag = dclenv !== 'org' ? ` --dclenv ${dclenv}` : ''
+      const command = `${godotEditorPath} --rendering-driver opengl3 --avatar-renderer --avatars ${avatarDataPath}${dclenvFlag}`
       logger.debug(
         `about to exec: explorerPath: ${explorerPath}, display: ${process.env.DISPLAY}, command: ${command}, timeout: ${timeout}`
       )

--- a/test/unit/adapters/godot.spec.ts
+++ b/test/unit/adapters/godot.spec.ts
@@ -2,7 +2,7 @@ import { createTestMetricsComponent } from '@well-known-components/metrics'
 import { createConfigComponent } from '@well-known-components/env-config-provider'
 import { createLogComponent } from '@well-known-components/logger'
 import { ExtendedAvatar } from '../../../src/types'
-import { createGodotSnapshotComponent, GodotComponent } from '../../../src/adapters/godot'
+import { createGodotSnapshotComponent, GodotComponent, inferDclEnvFromPeerUrl } from '../../../src/adapters/godot'
 import { metricDeclarations } from '../../../src/metrics'
 import { exec } from 'child_process'
 import { stat, writeFile, mkdir, rm } from 'fs/promises'
@@ -125,6 +125,116 @@ describe('when generating images with Godot', () => {
       expect(result.avatars).toHaveLength(2)
       expect(result.avatars[0].success).toBe(true)
       expect(result.avatars[1].success).toBe(true)
+    })
+  })
+
+  describe('and PEER_URL targets a zone catalyst', () => {
+    let zoneGodot: GodotComponent
+
+    beforeEach(async () => {
+      const zoneConfig = createConfigComponent(
+        {
+          PEER_URL: 'https://peer.decentraland.zone',
+          GODOT_BASE_TIMEOUT: '1000',
+          GODOT_AVATAR_TIMEOUT: '1000'
+        },
+        {}
+      )
+      zoneGodot = await createGodotSnapshotComponent({ logs, metrics, config: zoneConfig })
+      mockExec.mockImplementation((...args) => {
+        const callback = args.find((arg) => typeof arg === 'function')
+        callback(null, 'success', '')
+        return mockChildProcess
+      })
+      ;(stat as jest.Mock).mockResolvedValue({})
+    })
+
+    it('passes --dclenv zone to the godot binary', async () => {
+      await zoneGodot.generateImages(testAvatars)
+      const godotCall = mockExec.mock.calls.find(
+        ([cmd]: [string]) => typeof cmd === 'string' && cmd.includes('decentraland.godot.client')
+      )
+      expect(godotCall).toBeDefined()
+      expect(godotCall![0]).toContain('--dclenv zone')
+    })
+  })
+
+  describe('and PEER_URL targets the peer-testing catalyst', () => {
+    let todayGodot: GodotComponent
+
+    beforeEach(async () => {
+      const todayConfig = createConfigComponent(
+        {
+          PEER_URL: 'https://peer-testing.decentraland.org',
+          GODOT_BASE_TIMEOUT: '1000',
+          GODOT_AVATAR_TIMEOUT: '1000'
+        },
+        {}
+      )
+      todayGodot = await createGodotSnapshotComponent({ logs, metrics, config: todayConfig })
+      mockExec.mockImplementation((...args) => {
+        const callback = args.find((arg) => typeof arg === 'function')
+        callback(null, 'success', '')
+        return mockChildProcess
+      })
+      ;(stat as jest.Mock).mockResolvedValue({})
+    })
+
+    it('passes --dclenv today to the godot binary', async () => {
+      await todayGodot.generateImages(testAvatars)
+      const godotCall = mockExec.mock.calls.find(
+        ([cmd]: [string]) => typeof cmd === 'string' && cmd.includes('decentraland.godot.client')
+      )
+      expect(godotCall).toBeDefined()
+      expect(godotCall![0]).toContain('--dclenv today')
+    })
+  })
+
+  describe('and PEER_URL targets the org catalyst', () => {
+    let orgGodot: GodotComponent
+
+    beforeEach(async () => {
+      const orgConfig = createConfigComponent(
+        {
+          PEER_URL: 'https://peer.decentraland.org',
+          GODOT_BASE_TIMEOUT: '1000',
+          GODOT_AVATAR_TIMEOUT: '1000'
+        },
+        {}
+      )
+      orgGodot = await createGodotSnapshotComponent({ logs, metrics, config: orgConfig })
+      mockExec.mockImplementation((...args) => {
+        const callback = args.find((arg) => typeof arg === 'function')
+        callback(null, 'success', '')
+        return mockChildProcess
+      })
+      ;(stat as jest.Mock).mockResolvedValue({})
+    })
+
+    it('does not pass --dclenv', async () => {
+      await orgGodot.generateImages(testAvatars)
+      const godotCall = mockExec.mock.calls.find(
+        ([cmd]: [string]) => typeof cmd === 'string' && cmd.includes('decentraland.godot.client')
+      )
+      expect(godotCall).toBeDefined()
+      expect(godotCall![0]).not.toContain('--dclenv')
+    })
+  })
+
+  describe('inferDclEnvFromPeerUrl', () => {
+    it('returns zone for *.decentraland.zone hosts', () => {
+      expect(inferDclEnvFromPeerUrl('https://peer.decentraland.zone')).toBe('zone')
+      expect(inferDclEnvFromPeerUrl('https://peer-ap1.decentraland.zone')).toBe('zone')
+    })
+
+    it('returns today for the peer-testing host', () => {
+      expect(inferDclEnvFromPeerUrl('https://peer-testing.decentraland.org')).toBe('today')
+    })
+
+    it('returns org for production hosts and unknown values', () => {
+      expect(inferDclEnvFromPeerUrl('https://peer.decentraland.org')).toBe('org')
+      expect(inferDclEnvFromPeerUrl('http://localhost:3000')).toBe('org')
+      expect(inferDclEnvFromPeerUrl('not a url')).toBe('org')
     })
   })
 


### PR DESCRIPTION
## Summary

The renderer's wearable fetcher reads `urls::peer_content()` keyed off a global `dclenv` (default `org`), set via `DclGlobal.set_dcl_environment(...)`. Pointing `PEER_URL` at `.zone` fixed the profile fetch but **not** the `entities/active` POST for wearables — so testnet (Amoy) wearable collections returned `null` and `.zone`-deployed instances rendered bald avatars.

This wires up the dclenv automatically based on the existing `PEER_URL` config, no new env vars required.

## Changes

- **`src/adapters/godot.ts`**: derive `dclenv` from `PEER_URL` hostname (`*.decentraland.zone` → `zone`, `peer-testing.decentraland.org` → `today`, else `org`) and pass `--dclenv <env>` to the godot binary when not org.
- **`Dockerfile`**: bump `godot-explorer` base image from `8ed31d84` to `be6db73f`, the first published image that includes the `--dclenv` flag (added in upstream `22fca47c`).
- **Tests**: 6 new unit cases — one per resolution (zone/today/org), plus a pure-function suite for `inferDclEnvFromPeerUrl`. All 10 godot adapter tests pass; full unit suite (148 tests) green.

## Why no `DCL_ENV` env var?

Each profile-images deployment already has its own `PEER_URL` (one for `.org`, one for `.zone`); the hostname unambiguously selects the dclenv. Adding a separate `DCL_ENV` would just be a way to disagree with `PEER_URL`.

## Reference

See `decentraland/godot-explorer/docs/PROFILE_IMAGE.md` ("Catalyst environment") for the full explanation of why `--catalyst` / `--content` alone are not enough and why `--dclenv` is the right knob.

## Test plan

- [x] `npx jest --testPathPattern=test/unit` — 148/148 pass
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [ ] Smoke-test on the `.zone` deployment that an Amoy-only wearable now renders (pre-fix it would have come back bald).
- [ ] Smoke-test on the `.org` deployment that nothing regressed (no `--dclenv` flag should be passed).